### PR TITLE
Instantiate _isolateSession when created fromAddress

### DIFF
--- a/lib/src/ort_session.dart
+++ b/lib/src/ort_session.dart
@@ -72,6 +72,7 @@ class OrtSession {
   OrtSession.fromAddress(int address) {
     _ptr = ffi.Pointer.fromAddress(address);
     _init();
+    _isolateSession = OrtIsolateSession(this);
   }
 
   _init() {


### PR DESCRIPTION
Unbreaks `release()` for `OrtSession`s created `fromAddress`